### PR TITLE
Normalisation works with substitution matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pypirc
 build/
 dist/
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The following algorithms accept the `scoring_matrix` keyword argument as a param
 
 - NeedlemanWunsch
 - WatermanSmithBeyer
-- Gotoh
 - Hirschberg
 - FengDoolittle (only applies to above mentioned pairwise algorithms)
 
@@ -305,9 +304,6 @@ print(needleman62.align(seq1, seq2))
 Interested in contributing to Goombay? Please review our [Contribution Guidelines](https://github.com/lignum-vitae/goombay/blob/master/docs/CONTRIBUTING.md) for detailed instructions on how to get involved.
 
 # Caveats
-
-> [!CAUTION]
-> There are some issues with alignment to be tackled in later releases.
 
 Note that due to the fact that the Hamming distance does not allow for insertions or deletions, the "aligned sequence" that is returned is just the original sequences in a formatted string.
 This is due to the fact that actually aligning the two sequences using this algorithm would just lead to two lines of the query sequence.

--- a/goombay/align/base.py
+++ b/goombay/align/base.py
@@ -34,24 +34,32 @@ class GlobalBase(ABC):
         return 1 - self.normalized_similarity(query_seq, subject_seq)
 
     def normalized_similarity(self, query_seq: str, subject_seq: str) -> float:
+        if query_seq == subject_seq:
+            return 1.0
+        if not query_seq or not subject_seq:
+            return 0.0
         raw_score = self.similarity(query_seq, subject_seq)
-        max_len = len(max(query_seq, subject_seq, key=len))
         if self.has_sub_mat:
-            max_val = float("-inf")
-            min_val = float("inf")
-            avail_keys = list(self.sub_mat["A"].keys())
-            for key in avail_keys:
-                temp_max = max(self.sub_mat[key].values())
-                temp_min = min(self.sub_mat[key].values())
-                max_val = temp_max if temp_max > max_val else max_val
-                min_val = temp_min if temp_min < min_val else min_val
-            max_possible = max_len * max_val
-            min_possible = -max_len * abs(min_val)
+            max_possible = 0
+            min_possible = 0
+            if hasattr(self, "new_gap"):
+                gap = -self.continued_gap
+            else:
+                gap = -self.gap
+            for q, s in zip(query_seq, subject_seq):
+                q_match = self.sub_mat[q][q]
+                s_match = self.sub_mat[s][s]
+                qs_match = self.sub_mat[q][s]
+                candidates = (gap, q_match, s_match, qs_match)
+                max_possible += max(candidates)
+                min_possible += min(candidates)
         else:
+            max_len = len(max(query_seq, subject_seq, key=len))
             max_possible = max_len * self.match
             min_possible = -max_len * self.mismatch
-        score_range = max_possible - min_possible
-        return (raw_score - min_possible) / score_range
+        score_range = max_possible + abs(min_possible)
+
+        return (raw_score + abs(min_possible)) / score_range
 
     def align(self, query_seq: str, subject_seq: str) -> str:
         _, pointer_matrix = self(query_seq, subject_seq)

--- a/goombay/align/edit.py
+++ b/goombay/align/edit.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 def main():
-    from biobase.matrix import Blosum
+    from biobase.matrix import Blosum, Pam
 
     """
     qqs = "HOLYWATERISABLESSING"
@@ -47,12 +47,12 @@ def main():
         print()
     print(waterman_smith_beyer.matrix("TRATE", "TRACE"))
     """
-    query = "CGCAAATGGGCGGTAGGCGTG"
-    subject = "CTTTATCCAGCCCTCAC"
+    query = "ACTG"
+    subject = "AAAA"
 
-    print(needleman_wunsch.normalized_distance(query, subject))
-    nw_62 = NeedlemanWunsch(scoring_matrix=Blosum(62))
-    print(nw_62.normalized_distance(query, subject))
+    print(needleman_wunsch.matrix(query, subject))
+    print(gotoh.normalized_similarity(query, subject))
+    print(needleman_wunsch.normalized_similarity(query, subject))
 
 
 class WagnerFischer(_GlobalBase):  # Levenshtein Distance
@@ -554,7 +554,7 @@ class WatermanSmithBeyer(_GlobalBase):
 
 
 class Gotoh(_GlobalBase):
-    supports_scoring_matrix = True
+    supports_scoring_matrix = False
 
     def __init__(
         self,
@@ -562,19 +562,13 @@ class Gotoh(_GlobalBase):
         mismatch: int = 1,
         new_gap: int = 2,
         continued_gap: int = 1,
-        scoring_matrix=None,
     ) -> None:
         self.match = match
         self.mismatch = mismatch
         self.new_gap = new_gap
         self.continued_gap = continued_gap
         self.has_sub_mat = False
-        self.sub_mat = scoring_matrix
-        if scoring_matrix is not None:
-            self.match_func = lambda a, b: scoring_matrix[a][b]
-            self.has_sub_mat = True
-        else:
-            self.match_func = lambda a, b: self.match if a == b else -self.mismatch
+        self.match_func = lambda a, b: self.match if a == b else -self.mismatch
 
     def __call__(
         self, query_seq: str, subject_seq: str
@@ -944,10 +938,10 @@ class Hirschberg:
 
     def normalized_distance(self, query_seq: str, subject_seq: str) -> float:
         """Calculate normalized distance between sequences"""
-        if not query_seq or not subject_seq:
-            return 1.0
         if query_seq == subject_seq:
             return 0.0
+        if not query_seq or not subject_seq:
+            return 1.0
 
         raw_dist = self.distance(query_seq, subject_seq)
         max_len = max(len(query_seq), len(subject_seq))
@@ -959,11 +953,6 @@ class Hirschberg:
 
     def normalized_similarity(self, query_seq: str, subject_seq: str) -> float:
         """Calculate normalized similarity between sequences"""
-        if not query_seq or not subject_seq:
-            return 0.0
-        if query_seq == subject_seq:
-            return 1.0
-
         return 1.0 - self.normalized_distance(query_seq, subject_seq)
 
     def matrix(self, query_seq: str, subject_seq: str) -> NDArray[float64]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goombay"
-version = "0.24.2"
+version = "0.24.3"
 authors = [{ name = "Andrew Hennis", email = "andrew.mr.hennis@gmail.com" }]
 description = "Python implementation of several sequence alignment algorithms such as Waterman-Smith-Beyer, Gotoh, and Needleman-Wunsch intended to calculate distance, show alignment, and display the underlying matrices."
 readme = "README.md"

--- a/tests/test_edit/test_SubMatrix.py
+++ b/tests/test_edit/test_SubMatrix.py
@@ -1,0 +1,108 @@
+import unittest
+from biobase.matrix import Blosum, Pam
+from goombay import NeedlemanWunsch, Gotoh, Hirschberg, WatermanSmithBeyer
+
+
+class TestSubstitutionMatrices(unittest.TestCase):
+    """Test suite for substitution matrices that can be used with global alignment algorithms"""
+
+    def setUp(self):
+        """Initialize algorithm for tests"""
+        self.nw = NeedlemanWunsch()
+        self.g = Gotoh()
+        self.h = Hirschberg()
+        self.nwb62 = NeedlemanWunsch(scoring_matrix=Blosum(62))
+        self.hb62 = Hirschberg(scoring_matrix=Blosum(62))
+        self.wsbp250 = WatermanSmithBeyer(scoring_matrix=Pam(250))
+
+    def test_identical_sequences(self):
+        """Test behavior with identical sequences"""
+        seq = "ARLP"
+
+        self.assertEqual(self.nw.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.nw.normalized_distance(seq, seq), 0.0)
+
+        self.assertEqual(self.g.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.g.normalized_distance(seq, seq), 0.0)
+
+        self.assertEqual(self.h.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.h.normalized_distance(seq, seq), 0.0)
+
+        self.assertEqual(self.nwb62.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.nwb62.normalized_distance(seq, seq), 0.0)
+
+        self.assertEqual(self.hb62.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.hb62.normalized_distance(seq, seq), 0.0)
+
+        self.assertEqual(self.wsbp250.normalized_similarity(seq, seq), 1.0)
+        self.assertEqual(self.wsbp250.normalized_distance(seq, seq), 0.0)
+
+    def test_worst_alignment_score(self):
+        """Test behavior with identical sequences"""
+        query = "LLLLL"
+        subject = "DDDDD"
+
+        # Test normalization
+        self.assertEqual(self.nw.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.nw.normalized_distance(query, subject), 1.0)
+
+        self.assertEqual(self.g.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.g.normalized_distance(query, subject), 1.0)
+
+        self.assertEqual(self.h.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.h.normalized_distance(query, subject), 1.0)
+
+        self.assertEqual(self.nwb62.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.nwb62.normalized_distance(query, subject), 1.0)
+
+        self.assertEqual(self.hb62.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.hb62.normalized_distance(query, subject), 1.0)
+
+        self.assertEqual(self.wsbp250.normalized_similarity(query, subject), 0.0)
+        self.assertEqual(self.wsbp250.normalized_distance(query, subject), 1.0)
+
+    def test_different_length_sequences(self):
+        query = "MKT"
+        subject = "MKTTT"
+
+        # With identical prefix but gaps at the end
+        self.assertGreaterEqual(self.nw.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.nw.normalized_similarity(query, subject), 1.0)
+
+        self.assertGreaterEqual(self.g.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.g.normalized_similarity(query, subject), 1.0)
+
+        self.assertGreaterEqual(self.h.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.h.normalized_similarity(query, subject), 1.0)
+
+        self.assertGreaterEqual(self.nwb62.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.nwb62.normalized_similarity(query, subject), 1.0)
+
+        self.assertGreaterEqual(self.hb62.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.hb62.normalized_similarity(query, subject), 1.0)
+
+        self.assertGreaterEqual(self.wsbp250.normalized_similarity(query, subject), 0.0)
+        self.assertLessEqual(self.wsbp250.normalized_similarity(query, subject), 1.0)
+
+    def test_pam250_negative_scores(self):
+        query = "AW"
+        subject = "WA"
+        sim_score = self.wsbp250.normalized_similarity(query, subject)
+        dist_score = self.wsbp250.normalized_distance(query, subject)
+        self.assertGreaterEqual(sim_score, 0.0)
+        self.assertGreaterEqual(dist_score, 0.0)
+        self.assertLessEqual(sim_score, 1.0)
+        self.assertLessEqual(dist_score, 1.0)
+
+    def test_empty_sequences(self):
+        self.assertEqual(self.nw.normalized_similarity("", ""), 1.0)
+        self.assertEqual(self.g.normalized_similarity("", ""), 1.0)
+        self.assertEqual(self.h.normalized_similarity("", ""), 1.0)
+
+        self.assertEqual(self.nw.normalized_distance("", ""), 0.0)
+        self.assertEqual(self.g.normalized_distance("", ""), 0.0)
+        self.assertEqual(self.h.normalized_distance("", ""), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Normalisation wasn't working properly when substitution matrices were introduced. Fixed all issues with normalisation. Learnt that updated normalisation didn't work when an algorithm had an affine gap and a substitution matrix, so removed Gotoh from the list of algorithms that could accept substitution matrices.

I may, in the future, explore the possibility of obtaining an accurate normalisation from Gotoh when it uses a substitution matrix. For now, Gotoh without a sub mat still passes all of the tests laid out in the test directory.

Summary of changes:
Previously worst possible mismatch was chosen from the substitution matrix, which would make the normalization of algorithms show an incorrect value for all mismatches due to the function calculating the lowest possible score for a letter that might not even be present in the sequence. Instead, the algorithm now evaluates the best and worst score for each position and accumulates this to create the max possible and min possible scores
HOWEVER, Gototh, which uses an affine gap, does not agree with these changes. WSB, NW, and Hirschberg, which all use linear gap penalties, work well with the new normalisation function.